### PR TITLE
phpunit4以降でabstract classにする必要ある

### DIFF
--- a/Test/Case/Controller/RoomsRolesUsersController/EditTest.php
+++ b/Test/Case/Controller/RoomsRolesUsersController/EditTest.php
@@ -149,7 +149,6 @@ class RoomsRolesUsersControllerEditTest extends RoomsControllerTestCase {
  */
 	private function __dataSave() {
 		$mock = array('components' => array(
-			'Auth' => array('user'),
 			'Security',
 		));
 		$this->generate('Rooms.' . Inflector::camelize($this->_controller), $mock);

--- a/TestSuite/RoomsControllerTestCase.php
+++ b/TestSuite/RoomsControllerTestCase.php
@@ -20,7 +20,7 @@ App::uses('NetCommonsControllerTestCase', 'NetCommons.TestSuite');
  * @package NetCommons\Rooms\TestSuite
  * @codeCoverageIgnore
  */
-class RoomsControllerTestCase extends NetCommonsControllerTestCase {
+abstract class RoomsControllerTestCase extends NetCommonsControllerTestCase {
 
 /**
  * Fixtures


### PR DESCRIPTION
phpunit4以降でstaticExpectsが使えなくなった
https://github.com/NetCommons3/NetCommons3/issues/998