### PR TITLE
ChildRoomのhasManyアソシエーションを解除するunBindが一時的なものであったため、unbindになっていなかったことに対応

### DIFF
--- a/Model/Behavior/RoomBehavior.php
+++ b/Model/Behavior/RoomBehavior.php
@@ -173,7 +173,7 @@ class RoomBehavior extends ModelBehavior {
 		$model->Room->unbindModel(array(
 			'belongsTo' => array('ParentRoom'),
 			'hasMany' => array('ChildRoom')
-		));
+		), false);
 		$spaces = $model->Room->find('all', array(
 			'recursive' => 1,
 			'conditions' => array(
@@ -181,6 +181,33 @@ class RoomBehavior extends ModelBehavior {
 			),
 			'order' => 'Room.lft'
 		));
+		// 外したものを戻しておく
+		$model->Room->bindModel(array(
+			'belongsTo' => array(
+				'ParentRoom' => array(
+					'className' => 'Rooms.Room',
+					'foreignKey' => 'parent_id',
+					'conditions' => '',
+					'fields' => '',
+					'order' => ''
+				)
+			),
+			'hasMany' => array(
+				'ChildRoom' => array(
+					'className' => 'Rooms.Room',
+					'foreignKey' => 'parent_id',
+					'dependent' => false,
+					'conditions' => '',
+					'fields' => '',
+					'order' => '',
+					'limit' => '',
+					'offset' => '',
+					'exclusive' => '',
+					'finderQuery' => '',
+					'counterQuery' => ''
+				),
+			),
+		), false);
 
 		$spaces = Hash::combine($spaces, '{n}.Room.id', '{n}');
 

--- a/Model/Behavior/RoomBehavior.php
+++ b/Model/Behavior/RoomBehavior.php
@@ -170,6 +170,8 @@ class RoomBehavior extends ModelBehavior {
 		}
 
 		//スペースデータ取得
+		$bindParentRoom = $model->Room->belongsTo['ParentRoom'];
+		$bindChildRoom = $model->Room->hasMany['ChildRoom'];
 		$model->Room->unbindModel(array(
 			'belongsTo' => array('ParentRoom'),
 			'hasMany' => array('ChildRoom')
@@ -183,30 +185,8 @@ class RoomBehavior extends ModelBehavior {
 		));
 		// 外したものを戻しておく
 		$model->Room->bindModel(array(
-			'belongsTo' => array(
-				'ParentRoom' => array(
-					'className' => 'Rooms.Room',
-					'foreignKey' => 'parent_id',
-					'conditions' => '',
-					'fields' => '',
-					'order' => ''
-				)
-			),
-			'hasMany' => array(
-				'ChildRoom' => array(
-					'className' => 'Rooms.Room',
-					'foreignKey' => 'parent_id',
-					'dependent' => false,
-					'conditions' => '',
-					'fields' => '',
-					'order' => '',
-					'limit' => '',
-					'offset' => '',
-					'exclusive' => '',
-					'finderQuery' => '',
-					'counterQuery' => ''
-				),
-			),
+			'belongsTo' => array('ParentRoom' => $bindParentRoom),
+			'hasMany' => array('ChildRoom' => $bindChildRoom),
 		), false);
 
 		$spaces = Hash::combine($spaces, '{n}.Room.id', '{n}');


### PR DESCRIPTION
https://github.com/NetCommons3/NetCommons3/issues/1072
unbindを永続的なものとして、直後に明示的にbindを実施