### PR TITLE
サイト全体のRoom.idを4にしているが、auto_increment任せにしていて、環境によっては、ずれてしまい、うまくインストールさ…

### DIFF
--- a/Config/Migration/1479455827_switch_boxes.php
+++ b/Config/Migration/1479455827_switch_boxes.php
@@ -67,6 +67,7 @@ class SwitchBoxes extends NetCommonsMigration {
 		'Room' => array(
 			//サイト全体
 			array(
+				'id' => '4',
 				'space_id' => '1',
 				'page_id_top' => null,
 				'root_id' => null,


### PR DESCRIPTION
サイト全体のRoom.idを4にしているが、auto_increment任せにしていて、環境によっては、ずれてしまい、うまくインストールされない可能性がある。そのため固定とする。
https://github.com/NetCommons3/NetCommons3/issues/1430