### PR TITLE
大量のinfoログ出力を削除

### DIFF
--- a/Model/Behavior/DeleteRoomAssociationsBehavior.php
+++ b/Model/Behavior/DeleteRoomAssociationsBehavior.php
@@ -175,7 +175,6 @@ class DeleteRoomAssociationsBehavior extends ModelBehavior {
 
 			$sql = 'DELETE FROM ' . $tableName .
 					' WHERE ' . $field . ' IN (' . implode(', ', $targets) . ')';
-			CakeLog::info('[room deleting] ' . $sql);
 			$model->query($sql);
 		}
 


### PR DESCRIPTION
Info: [room deleting] DELETE FROM ...
なログが全テーブルx各関連フィールド分出力されていたので削除