### PR TITLE
fix: ルームの作成時に、参加者の選択画面で役割を変更した後で基本設定に戻って、「すべての会員をデフォルトで参加させる」にチェックを入れ…

### DIFF
--- a/Controller/RoomAddController.php
+++ b/Controller/RoomAddController.php
@@ -165,6 +165,11 @@ class RoomAddController extends RoomsAppController {
 			//他言語が入力されていない場合、Currentの言語データをセット
 			$this->SwitchLanguage->setM17nRequestValue();
 
+			$defaultParticipation = $this->request->data['Room']['default_participation'] ?? null;
+			if ($this->Session->read('RoomAdd.Room.default_participation') !== $defaultParticipation) {
+				$this->Session->delete('RoomsRolesUsers');
+			}
+
 			//登録処理
 			$this->request->data['Room']['in_draft'] = true;
 			$room = $this->Room->saveRoom($this->request->data);


### PR DESCRIPTION
…て登録すると、役割のデータが二重で登録される